### PR TITLE
Update GAV to ShrinkWrap Org

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,11 +2,13 @@
    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <parent>
-      <groupId>br.net.gastaldi.docker</groupId>
-      <artifactId>docker-descriptors-parent</artifactId>
+      <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+      <artifactId>docker-descriptors-parent-docker</artifactId>
       <version>0.0.1-SNAPSHOT</version>
+      <relativePath>../pom.xml</relativePath>
    </parent>
-   <artifactId>docker-descriptors-api</artifactId>
+   <artifactId>shrinkwrap-descriptors-api-docker</artifactId>
+   <name>Docker Descriptors :: API</name>
    <dependencies>
       <dependency>
          <groupId>org.jboss.shrinkwrap.descriptors</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -2,15 +2,17 @@
    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <parent>
-      <groupId>br.net.gastaldi.docker</groupId>
-      <artifactId>docker-descriptors-parent</artifactId>
+      <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+      <artifactId>docker-descriptors-parent-docker</artifactId>
       <version>0.0.1-SNAPSHOT</version>
+      <relativePath>../pom.xml</relativePath>
    </parent>
-   <artifactId>docker-descriptors</artifactId>
+   <artifactId>shrinkwrap-descriptors-impl-docker</artifactId>
+   <name>Docker Descriptors :: Impl</name>
    <dependencies>
       <dependency>
-         <groupId>br.net.gastaldi.docker</groupId>
-         <artifactId>docker-descriptors-api</artifactId>
+         <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+         <artifactId>shrinkwrap-descriptors-api-docker</artifactId>
       </dependency>
       <dependency>
          <groupId>org.jboss.shrinkwrap.descriptors</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
       <version>16</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
-   <groupId>br.net.gastaldi.docker</groupId>
-   <artifactId>docker-descriptors-parent</artifactId>
+   <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+   <artifactId>docker-descriptors-parent-docker</artifactId>
    <version>0.0.1-SNAPSHOT</version>
    <packaging>pom</packaging>
-   <name>Docker Descriptors :: Parent</name>
+   <name>Docker Descriptors :: Parent Docker</name>
    <modules>
       <module>api</module>
       <module>impl</module>
@@ -37,13 +37,13 @@
    <dependencyManagement>
       <dependencies>
          <dependency>
-            <groupId>br.net.gastaldi.docker</groupId>
-            <artifactId>docker-descriptors-api</artifactId>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-api-docker</artifactId>
             <version>${project.version}</version>
          </dependency>
          <dependency>
-            <groupId>br.net.gastaldi.docker</groupId>
-            <artifactId>docker-descriptors</artifactId>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-impl-docker</artifactId>
             <version>${project.version}</version>
          </dependency>
          <dependency>
@@ -56,9 +56,8 @@
       </dependencies>
    </dependencyManagement>
    <scm>
-      <connection>scm:git:git://github.com/gastaldi/docker-descriptors.git</connection>
-      <developerConnection>scm:git:git@github.com:gastaldi/docker-descriptors.git</developerConnection>
-      <url>http://github.com/gastaldi/docker-descriptors</url>
-      <tag>HEAD</tag>
+      <connection>scm:git:git://github.com/shrinkwrap/descriptors-docker.git</connection>
+      <developerConnection>scm:git:git@github.com:shrinkwrap/descriptors-docker.git</developerConnection>
+      <url>http://github.com/shrinkwrap/descriptors-docker</url>
    </scm>
 </project>


### PR DESCRIPTION
Not 100% sure if we should reuse Descriptors groupId here or create a sub groupid?

```
org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-api-docker
```

vs

```
org.jboss.shrinkwrap.descriptors.docker:shrinkwrap-descriptors-api-docker
```
